### PR TITLE
Issue #73 - update error message for data < 14 days

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,4 @@
 # ViroReportR (development version)
 
 * Added a `NEWS.md` file to track changes to the package.
+* Added `seed` parameter to `generate_forecast()` to enable reproducible outputs in forecasting.

--- a/R/fit_epiestim_model_functions.R
+++ b/R/fit_epiestim_model_functions.R
@@ -126,7 +126,7 @@ fit_epiestim_model <- function(data, window_size = 7L,type = NULL, mean_si = NUL
 #'   \item{incidence}{projected number of daily confirmed cases}
 #'   \item{sim}{simulation run number}
 #' }
-#' 
+#'
 project_epiestim_model <- function(data, model_fit, n_days = 7, n_sim = 1000) {
   confirm <- NULL
 
@@ -216,6 +216,13 @@ project_epiestim_model <- function(data, model_fit, n_days = 7, n_sim = 1000) {
 #'   Cutoff parameter for smoothing. Only used if \code{smooth_data = TRUE}.
 #'   Default is 10.
 #'
+#' @param seed *Integer or NULL*
+#'   Random seed used to ensure reproducibility of the forecast.
+#'   If provided, the same input data will produce identical results across runs.
+#'   If set to \code{NULL}, results may vary between runs due to stochastic
+#'   sampling in reproduction number estimation and projection steps.
+#'   Default is \code{123}.
+#'
 #' @param ...
 #'   Additional arguments passed to \code{\link{fit_epiestim_model}}.
 #'
@@ -227,7 +234,7 @@ project_epiestim_model <- function(data, model_fit, n_days = 7, n_sim = 1000) {
 #' @seealso
 #' \code{\link{fit_epiestim_model}} for reproduction number estimation,
 #' \code{\link{project_epiestim_model}} for forward simulations.
-#' 
+#'
 #' @importFrom incidence incidence
 #' @importFrom rlang .data
 #'
@@ -254,7 +261,7 @@ project_epiestim_model <- function(data, model_fit, n_days = 7, n_sim = 1000) {
 #'   type = "rsv",
 #'   smooth_data = FALSE
 #' )
-#' 
+#'
 
 generate_forecast <- function(
     data,
@@ -264,8 +271,12 @@ generate_forecast <- function(
     type = NULL,
     smooth_data = FALSE,
     smoothing_cutoff = 10,
+    seed = 123,
     ...
 ){
+
+  # Set random seed for reproducibility (controls stochastic components in Rt estimation and projection simulation)
+  if (!is.null(seed)) set.seed(seed)
 
   data <- clean_sample_data(data,
                             start_date)

--- a/R/generate_forecast_report.R
+++ b/R/generate_forecast_report.R
@@ -23,6 +23,14 @@
 #'
 #'   This will produce a report where influenza A and RSV seasons run from
 #'   September 1, 2024 to March 1, 2025, while no season is defined for SARS-CoV-2.
+#'
+#' @param seed *Integer or NULL*
+#'   Random seed used to ensure reproducibility of the forecast.
+#'   If provided, the same input data will produce identical results across runs.
+#'   If set to \code{NULL}, results may vary between runs due to stochastic
+#'   sampling in reproduction number estimation and projection steps.
+#'   Default is \code{123}.
+#'
 #' @import kableExtra cowplot
 #' @return Invisibly returns the path to the rendered HTML report.
 #' @export
@@ -47,7 +55,7 @@
 #' tmp_dir <- tempdir() # temporary directory for example for saving data
 #' data_path <- file.path(tmp_dir, "simulated_data.csv")
 #' write.csv(df, data_path, row.names = FALSE)
-#' 
+#'
 #' output_path <- tempdir() # output directory for report (temporary as example)
 #' generate_forecast_report(input_data_dir = data_path,
 #'                          output_dir = output_path,
@@ -61,7 +69,8 @@ generate_forecast_report <- function(input_data_dir = NULL,
                                      n_days = 7,
                                      validate_window_size = 7,
                                      smooth = FALSE,
-                                     disease_season = NULL) {
+                                     disease_season = NULL,
+                                     seed = 123) {
 
   # check that input_data_dir exists
   if (is.null(input_data_dir) || !file.exists(input_data_dir)) {
@@ -138,27 +147,28 @@ generate_forecast_report <- function(input_data_dir = NULL,
     }
   }
 
-  template <- system.file("vriforecasting_report.Rmd", package = "ViroReportR") 
-  stopifnot(nzchar(template)) 
-  tmp_rmd <- tempfile(fileext = ".Rmd") 
-  file.copy(template, tmp_rmd, overwrite = TRUE) 
-  dir.create(output_dir, showWarnings = FALSE, recursive = TRUE) 
-  out_file <- file.path(output_dir, "vriforecasting_report.html") 
-  rendered_path <- rmarkdown::render( 
-    input = tmp_rmd, 
-    output_file = basename(out_file), 
-    output_dir = dirname(out_file), 
-    intermediates_dir = tempdir(), 
-    clean = TRUE, 
-    params = list( 
-      n_days = n_days, 
-      filepath = input_data_dir, 
-      validate_window_size = validate_window_size, 
-      smooth = smooth, 
-      disease_season = disease_season 
-      ), 
+  template <- system.file("vriforecasting_report.Rmd", package = "ViroReportR")
+  stopifnot(nzchar(template))
+  tmp_rmd <- tempfile(fileext = ".Rmd")
+  file.copy(template, tmp_rmd, overwrite = TRUE)
+  dir.create(output_dir, showWarnings = FALSE, recursive = TRUE)
+  out_file <- file.path(output_dir, "vriforecasting_report.html")
+  rendered_path <- rmarkdown::render(
+    input = tmp_rmd,
+    output_file = basename(out_file),
+    output_dir = dirname(out_file),
+    intermediates_dir = tempdir(),
+    clean = TRUE,
+    params = list(
+      n_days = n_days,
+      filepath = input_data_dir,
+      validate_window_size = validate_window_size,
+      smooth = smooth,
+      disease_season = disease_season,
+      seed = seed
+      ),
     envir = new.env(parent = globalenv()),
-    quiet = TRUE ) 
-  return(rendered_path) 
+    quiet = TRUE )
+  return(rendered_path)
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -128,8 +128,15 @@ check_epiestim_format <- function(data){
 #'
 #' @noRd
 check_min_days <- function(data){
-  if(nrow(data) < 14){
-    stop("At least 14 days of data are needed.")
+  n_days <- nrow(data)
+
+  if(n_days < 14){
+    stop(
+      sprintf(
+        "After removing leading zero-confirmation dates, only %s days of data remain. At least 14 days are required.",
+        n_days
+      )
+    )
   }
 }
 

--- a/R/validation_functions.R
+++ b/R/validation_functions.R
@@ -24,6 +24,12 @@
 #'   to forecasting (default: `FALSE`).
 #' @param smoothing_cutoff Numeric. Threshold used for smoothing when
 #'   `smooth_data = TRUE` (default: `10`).
+#' @param seed *Integer or NULL*
+#'   Random seed used to ensure reproducibility of the forecast.
+#'   If provided, the same input data will produce identical results across runs.
+#'   If set to \code{NULL}, results may vary between runs due to stochastic
+#'   sampling in reproduction number estimation and projection steps.
+#'   Default is \code{123}.
 #' @param ... Additional arguments passed to `generate_forecast()`.
 #'
 #' @return A list of forecast results, each element corresponding to one
@@ -40,7 +46,7 @@
 #'
 #' This results in a set of forecasts that can be compared to observed data to
 #' evaluate predictive performance across time.
-#' 
+#'
 #' @examples
 #' data <- simulate_data()
 #' formatted_data <- get_aggregated_data(data,"date", "flu_a", "2024-10-16", "2024-12-31")
@@ -49,7 +55,7 @@
 #'
 #' @seealso [clean_sample_data()], [generate_forecast()]
 #' @export
-#' 
+#'
 
 generate_validation <- function(
     data,
@@ -60,6 +66,7 @@ generate_validation <- function(
     type = NULL,
     smooth_data = FALSE,
     smoothing_cutoff = 10,
+    seed = 123,
     ...
 ) {
   # clean and validate input
@@ -87,6 +94,7 @@ generate_validation <- function(
       type = type,
       smooth_data = smooth_data,
       smoothing_cutoff = smoothing_cutoff,
+      seed = seed,
       ...
     )
   })
@@ -141,14 +149,14 @@ generate_validation <- function(
 #'
 #' The function automatically excludes forecasts extending beyond the latest
 #' date in the observed model data.
-#' 
-#' @examples 
+#'
+#' @examples
 #' data <- simulate_data()
 #' formatted_data <- get_aggregated_data(data,"date", "flu_a", "2024-10-16", "2024-12-31")
 #' start_date <- ("2024-10-16")
 #' validation_results <- generate_validation(formatted_data, start_date, type ="flu_a")
 #' generate_validation_metric(formatted_data, validation_results)
-#' 
+#'
 #' @seealso [generate_validation()], [generate_forecast()]
 #' @export
 

--- a/inst/vriforecasting_report.Rmd
+++ b/inst/vriforecasting_report.Rmd
@@ -10,6 +10,7 @@ params:
   smooth: FALSE
   validate_window_size: 7
   disease_season: NULL
+  seed: 123
 ---
 
 
@@ -51,6 +52,7 @@ if(is.null(start_date)){
 forecast_horizon <- params$n_days
 smooth <- params$smooth
 validate_window_size <- params$validate_window_size
+seed <- params$seed
 ```
 
 
@@ -66,7 +68,8 @@ forecasts_results <- tibble(
       smooth_data = smooth,
       type = .y,
       n_days = forecast_horizon,
-      start_date = start_date
+      start_date = start_date,
+      seed = seed
     )
   )
 )
@@ -268,7 +271,8 @@ validation_results <- tibble(
       validate_window_size = params$validate_window_size,
       window_size = 7,
       smooth_data = smooth,
-      smoothing_cutoff = 10
+      smoothing_cutoff = 10,
+      seed = seed
     )
   )
 )

--- a/man/generate_forecast.Rd
+++ b/man/generate_forecast.Rd
@@ -12,6 +12,7 @@ generate_forecast(
   type = NULL,
   smooth_data = FALSE,
   smoothing_cutoff = 10,
+  seed = 123,
   ...
 )
 }
@@ -46,6 +47,13 @@ is \code{FALSE}.}
 \item{smoothing_cutoff}{\emph{Integer}
 Cutoff parameter for smoothing. Only used if \code{smooth_data = TRUE}.
 Default is 10.}
+
+\item{seed}{\emph{Integer or NULL}
+Random seed used to ensure reproducibility of the forecast.
+If provided, the same input data will produce identical results across runs.
+If set to \code{NULL}, results may vary between runs due to stochastic
+sampling in reproduction number estimation and projection steps.
+Default is \code{123}.}
 
 \item{...}{Additional arguments passed to \code{\link{fit_epiestim_model}}.}
 }

--- a/man/generate_forecast_report.Rd
+++ b/man/generate_forecast_report.Rd
@@ -10,7 +10,8 @@ generate_forecast_report(
   n_days = 7,
   validate_window_size = 7,
   smooth = FALSE,
-  disease_season = NULL
+  disease_season = NULL,
+  seed = 123
 )
 }
 \arguments{
@@ -42,6 +43,13 @@ sars_cov2 = NULL
 
 This will produce a report where influenza A and RSV seasons run from
 September 1, 2024 to March 1, 2025, while no season is defined for SARS-CoV-2.}
+
+\item{seed}{\emph{Integer or NULL}
+Random seed used to ensure reproducibility of the forecast.
+If provided, the same input data will produce identical results across runs.
+If set to \code{NULL}, results may vary between runs due to stochastic
+sampling in reproduction number estimation and projection steps.
+Default is \code{123}.}
 }
 \value{
 Invisibly returns the path to the rendered HTML report.

--- a/man/generate_validation.Rd
+++ b/man/generate_validation.Rd
@@ -13,6 +13,7 @@ generate_validation(
   type = NULL,
   smooth_data = FALSE,
   smoothing_cutoff = 10,
+  seed = 123,
   ...
 )
 }
@@ -43,6 +44,13 @@ to forecasting (default: \code{FALSE}).}
 
 \item{smoothing_cutoff}{Numeric. Threshold used for smoothing when
 \code{smooth_data = TRUE} (default: \code{10}).}
+
+\item{seed}{\emph{Integer or NULL}
+Random seed used to ensure reproducibility of the forecast.
+If provided, the same input data will produce identical results across runs.
+If set to \code{NULL}, results may vary between runs due to stochastic
+sampling in reproduction number estimation and projection steps.
+Default is \code{123}.}
 
 \item{...}{Additional arguments passed to \code{generate_forecast()}.}
 }

--- a/tests/testthat/test_generate_forecast.R
+++ b/tests/testthat/test_generate_forecast.R
@@ -4,7 +4,6 @@ test_that("generate_forecast returns expected output structure", {
   skip_if_not_installed("incidence")
 
   # create test data
-  set.seed(123)
   test_data <- simulate_data(days = 30,
                              peaks = c(flua = 60),
                              amplitudes = c(flua = 90),
@@ -83,5 +82,60 @@ test_that("generate_forecast errors with invalid input", {
       type = "rsv"
     ),
     "At least 14 days of data are needed."
+  )
+})
+
+test_that("generate_forecast is reproducible with seed", {
+  skip_if_not_installed("EpiEstim")
+  skip_if_not_installed("projections")
+  skip_if_not_installed("incidence")
+
+  # create test data
+  test_data <- simulate_data(
+    days = 30,
+    peaks = c(flua = 60),
+    amplitudes = c(flua = 90),
+    scales = c(flua = -0.01),
+    time_offset = 45
+  )
+
+  names(test_data) <- c("date", "confirm")
+
+  # same seed expect same result
+  res1 <- generate_forecast(
+    data = test_data,
+    start_date = as.Date("2024-01-07"),
+    n_days = 7,
+    type = "flu_a",
+    seed = 123
+  )
+
+  res2 <- generate_forecast(
+    data = test_data,
+    start_date = as.Date("2024-01-07"),
+    n_days = 7,
+    type = "flu_a",
+    seed = 123
+  )
+
+  expect_equal(
+    res1$forecast_res_quantiles,
+    res2$forecast_res_quantiles
+  )
+
+  # different seed expect different result
+  res3 <- generate_forecast(
+    data = test_data,
+    start_date = as.Date("2024-01-07"),
+    n_days = 7,
+    type = "flu_a",
+    seed = 456
+  )
+
+  expect_false(
+    identical(
+      res1$forecast_res_quantiles,
+      res3$forecast_res_quantiles
+    )
   )
 })

--- a/tests/testthat/test_generate_forecast.R
+++ b/tests/testthat/test_generate_forecast.R
@@ -81,7 +81,7 @@ test_that("generate_forecast errors with invalid input", {
       start_date = Sys.Date(),
       type = "rsv"
     ),
-    "At least 14 days of data are needed."
+    "After removing leading zero-confirmation dates, only 1 days of data remain. At least 14 days are required."
   )
 })
 


### PR DESCRIPTION
New error msg:
After removing leading zero-confirmation dates, only X days of data remain. At least 14 days are required.


Example:
Input confirm cases for each date:
14 days -> 12 days
0,0,1,2,3,4,5,6,7,8,9,10,11,12 -> 1,2,3,4,5,6,7,8,9,10,11,12

Error message:
After removing leading zero-confirmation dates, only 12 days of data remain. At least 14 days are required.
